### PR TITLE
書類｜書類登録・編集の下書き保存処理の修正

### DIFF
--- a/components/3_organisms/documents/document-form-editor.tsx
+++ b/components/3_organisms/documents/document-form-editor.tsx
@@ -175,7 +175,7 @@ export const DocumentFormEditor: React.FC<DocumentFormEditorProps> = ({
     hasUnsavedChanges,
   } = useDocumentForm({
     initialData: initialFormData,
-    onSubmit: async (data) => {
+    onSubmit: async (data, isDraft) => {
       setIsSaving(true);
       setSaveError(null);
 
@@ -210,10 +210,11 @@ export const DocumentFormEditor: React.FC<DocumentFormEditorProps> = ({
           success = true;
         }
 
-        if (success) {
-          setSaveSuccessMessage(isEditMode ? '書類を更新しました。' : '書類を保存しました。');
+        if (isDraft) {
+          setSaveSuccessMessage('下書きを保存しました。');
           setSaveSuccess(true);
-
+        } else if (success) {
+          setSaveSuccessMessage('書類を保存しました。');
           // 保存成功後の遷移
           if (isEditMode) {
             router.push(`/documents/view/${documentId}`);

--- a/hooks/useDocumentForm.ts
+++ b/hooks/useDocumentForm.ts
@@ -67,10 +67,10 @@ export const useDocumentForm = ({ onSubmit, initialData = {} }: UseDocumentFormO
           if (!isDraft) {
             reset({ ...initialFormData, ...initialData });
           }
-          setFormState((prev) => ({
+          setFormState(() => ({
             isSubmitting: false,
             isSavingDraft: false,
-            hasUnsavedChanges: isDraft ? prev.hasUnsavedChanges : false,
+            hasUnsavedChanges: false,
             error: null,
           }));
           return true;


### PR DESCRIPTION
### 概要
- 下書き保存成功時に通常保存と同じ処理が実行され、画面遷移が発生している

### 該当タスクのURL
https://github.com/ambi-tious/CareBase-staff/pull/273
https://github.com/ambi-tious/CareBase-staff/pull/236


### 対応内容
- 下書き保存の場合は、画面遷移処理をスキップするようにしました。
- 下書き保存成功時に未保存警告を非表示にしました。
  
### スクリーンショット
<img width="1028" height="733" alt="スクリーンショット 2025-08-29 11 46 07" src="https://github.com/user-attachments/assets/61c58778-630d-477d-b868-6ffea8f88cee" />

<img width="1066" height="742" alt="スクリーンショット 2025-08-29 11 45 25" src="https://github.com/user-attachments/assets/2b6be510-7617-4db7-8fd4-5e4b634706fb" />



### URL
- 書類登録
http://localhost:3000/documents/new

- 書類編集
http://localhost:3001/documents/edit/doc-4